### PR TITLE
Also watch new files in content watcher

### DIFF
--- a/content-watcher.js
+++ b/content-watcher.js
@@ -9,6 +9,7 @@ const process = require("process")
 let fileHashes = new Map()
 const IGNORE_DIRS = ["node_modules", ".git"]
 const WATCHED_EXTS = [".jsx", ".js", ".html"]
+var firstPass = true
 
 function putUpdate(path) {
   const data = JSON.stringify({
@@ -60,7 +61,7 @@ const pollDirectoryForChanges = dirPath => {
     } else {
       if (WATCHED_EXTS.includes(path.extname(newPath))) {
         const currentHash = hashFile(newPath)
-        if (fileHashes.has(newPath)) {
+        if (!firstPass) {
           const oldHash = fileHashes.get(newPath)
           if (oldHash !== currentHash) {
             console.log(`file changed ${newPath}`)
@@ -75,6 +76,7 @@ const pollDirectoryForChanges = dirPath => {
 
 const pollerFunction = () => {
   pollDirectoryForChanges(".")
+  firstPass = false
   setTimeout(pollerFunction, 1000)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skiller-whale-sync",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skiller-whale-sync",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A small module to sync file changes with the Skiller Whale backend",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/171507524

Previously, only files which were updated would be synced, and newly added files ignored. This change ensures that any newly added file will be tracked from the first time they are saved.