### PR TITLE
Decouple the uploading of files from the finding of changed files.

### DIFF
--- a/content-watcher.js
+++ b/content-watcher.js
@@ -14,6 +14,8 @@ var firstPass = true
 const hostName = process.env.SERVER_URL || "train.skillerwhale.com"
 const serverPort = process.env.SERVER_PORT || "443"
 
+const changed_files = []
+
 function postRequestOptions(path, headers) {
   return {
     hostname: hostName,
@@ -34,31 +36,52 @@ function sendPing() {
 }
 
 function putUpdate(path) {
-  const data = JSON.stringify({
-    relative_path: path,
-    contents: fs.readFileSync(path).toString()
-  })
-  const options = postRequestOptions(
-    `/attendances/${process.env.ATTENDANCE_ID}/file_snapshots`,
-    {
-      "Content-Type": "application/json",
-      "Content-Length": data.length
-    }
-  )
+  if(!changed_files.includes(path)) {
+    changed_files.push(path)
+  }
+}
 
-  const req = https.request(options, res => {
-    console.log(`status: ${res.statusCode}`)
+function uploadChangedFiles() {
+  // Iterate over a copy so the indexes don't change as we modify the array
+  changed_files_copy = [...changed_files]
 
-    res.on("data", d => {
-      process.stdout.write(d)
+  changed_files_copy.forEach(function(path) {
+    process.stdout.write(`uploading: ${path}\n`)
+    const data = JSON.stringify({
+      relative_path: path,
+      contents: fs.readFileSync(path).toString()
     })
-  })
+    const options = postRequestOptions(
+      `/attendances/${process.env.ATTENDANCE_ID}/file_snapshots`,
+      {
+        "Content-Type": "application/json",
+        "Content-Length": data.length
+      }
+    )
 
-  req.on("error", error => {
-    console.error(error)
+    const req = https.request(options, res => {
+      process.stdout.write(`status: ${res.statusCode}\n`)
+
+      res.on("data", d => {
+        process.stdout.write(d)
+        process.stdout.write("\n")
+      })
+
+      // 1xx and 2xx status codes are successful for our purposes
+      if(res.statusCode < 300) {
+        this_index = changed_files.indexOf(path)
+        if(this_index >= 0) {
+          changed_files.splice(this_index, 1)
+        }
+      }
+    })
+
+    req.on("error", error => {
+      console.error(error)
+    })
+    req.write(data)
+    req.end()
   })
-  req.write(data)
-  req.end()
 }
 
 function hashFile(path) {
@@ -93,10 +116,18 @@ const pollDirectoryForChanges = dirPath => {
 
 
 const pollerFunction = () => {
+  // Set the timeout first, to ensure an exception doesn't stop the recursion
+  setTimeout(pollerFunction, 1000)
   sendPing()
   pollDirectoryForChanges(".")
   firstPass = false
-  setTimeout(pollerFunction, 1000)
+}
+
+const uploaderFunction = () => {
+  // Set the timeout first, to ensure an exception doesn't stop the recursion
+  setTimeout(uploaderFunction, 1000)
+  uploadChangedFiles()
 }
 
 pollerFunction()
+uploaderFunction()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skiller-whale-sync",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -542,7 +542,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skiller-whale-sync",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A small module to sync file changes with the Skiller Whale backend",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This solves a problem where file modifications aren't uploaded the first time around, and are then lost.

Instead we maintain a queue of paths to be uploaded, with paths removed from the queue only when upload is successful.
