### PR TITLE
Add calculation for byte length

### DIFF
--- a/content-watcher.js
+++ b/content-watcher.js
@@ -49,9 +49,10 @@ function uploadFile(path) {
     relative_path: path,
     contents: fs.readFileSync(path).toString()
   })
+  const byteLength = new Blob([data]).size
   const headers = {
     "Content-Type": "application/json",
-    "Content-Length": data.length
+    "Content-Length": byteLength
   }
   const options = postRequestOptions("file_snapshots", headers)
   const req = https.request(options, function (res) {


### PR DESCRIPTION
I've tested this locally, and it can happily send data with and without unicode characters. I've also confirmed that sending Unicode data wasn't possible for the previous implementation.
