### PR TITLE
Use buffer instead of blob

### DIFF
--- a/content-watcher.js
+++ b/content-watcher.js
@@ -49,7 +49,7 @@ function uploadFile(path) {
     relative_path: path,
     contents: fs.readFileSync(path).toString()
   })
-  const byteLength = new Blob([data]).size
+  const byteLength = Buffer.byteLength(data)
   const headers = {
     "Content-Type": "application/json",
     "Content-Length": byteLength

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skiller-whale-sync",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A small module to sync file changes with the Skiller Whale backend",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When we tried the new fix out last week, it wasn't working: `ReferenceError: Blob is not defined`. I'm so used to working in the browser, where `Blob` is available globally, that I'm afraid I missed this in review.

We could import it, but `Buffer.byteLength` does the job just as well (and Fred pointed out it's been around for longer, so maybe safer if people have older versions of Node installed).

I created a dummy session and tested this, it seems to be working fine.